### PR TITLE
Future/yamamoto/dynamic routing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,6 +51,7 @@
         "streambuf": "cpp",
         "cinttypes": "cpp",
         "typeinfo": "cpp",
-        "queue": "cpp"
+        "queue": "cpp",
+        "set": "cpp"
     }
 }

--- a/lib/controllers/ArduinoController.hpp
+++ b/lib/controllers/ArduinoController.hpp
@@ -19,7 +19,7 @@ private:
 public:
   String receiveMessage(uint32_t to, String msg)
   {
-    StaticJsonDocument<200> inputDoc;
+    StaticJsonDocument<200> inputDoc;   //送信文字数．
 
     DeserializationError error = deserializeJson(inputDoc, msg);
 
@@ -81,6 +81,9 @@ public:
       outputDoc["contentName"] = outputData.getContentName();
       outputDoc["content"] = outputData.getContent();
 
+      std::string toStr = std::to_string(to);
+      outputDoc["relayNode"] = senderId + toStr;    //こういう書き方
+      
       String returnstr;
       serializeJson(outputDoc, returnstr);
       return returnstr;

--- a/lib/gateways/interface/FIBRepository.hpp
+++ b/lib/gateways/interface/FIBRepository.hpp
@@ -7,6 +7,7 @@
 
 class FIBRepository{
     virtual void save(FIBPair fibPair) {};
+    virtual void saveForDynamic(FIBPair fibPair, std::string faceId, int hopCount) {};
     virtual void remove(ContentName contentName) {};
     virtual bool find(ContentName contentName);
     virtual DestinationId get(ContentName contentName);

--- a/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
+++ b/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
@@ -1,0 +1,154 @@
+#ifndef INCLUDED_DIRECTEDDIFFUSION_FIB_REPOSITORY_hpp_
+#define INCLUDED_DIRECTEDDIFFUSION_FIB_REPOSITORY_hpp_
+
+#include "interface/FIBRepository.hpp"
+#include <map>       //std::map
+#include <algorithm> // std::min
+#include <utility>
+#include <queue>
+#include <ctime>
+#include <random> //random
+
+#define THRESHOLD 5
+#define MAX_PRIORITY 100
+// 優先度の最大値
+
+class DirectedDiffusionFIBRepository : public FIBRepository
+{
+private:
+    // FIB本体はstring，doublepairのvectorを含むMAP
+    std::map<std::string, std::set<std::pair<std::string, double>>> a_fib;
+    std::queue<std::string> a_fibManagement;
+    int const m_maxSize = 100;
+
+    // content IDと一致した配列を引数とし，複数の文字列型配列を戻り値とした関数．
+    std::set<std::string> pickupFibElement(std::set<std::pair<std::string, double>> dest)
+    {
+        double max = 0.0;
+        for (auto &x : dest)
+        {
+            if (x.second > max)
+                max = x.second;
+        }
+        double sum = 0.0;
+        for (auto &x : dest)
+        {
+            sum += x.second;
+        }
+        // 優先度の平均を求める
+        double average = sum / dest.size();
+
+        // 戻り値にするノードの数を端数切り捨てで求める．全体に対する割合は平均を最大で割った値の逆数
+        int nodeNum = static_cast<unsigned int>(dest.size() * (average / max));
+        if (nodeNum < 1)
+            nodeNum = 1;
+
+        std::mt19937 rd(static_cast<unsigned int>(std::time(nullptr)));
+        std::uniform_int_distribution<double> dist(0.0, 1.0);
+
+        // 戻り値用のfibリスト
+        std::set<std::pair<std::string, double>> fib_tmp = dest;
+        std::set<std::string> f_fib;
+
+        // 他に渡すFIBのリストを作成．計算量が増加しそうなので要改善
+        while ((f_fib.size() < nodeNum) || (fib_tmp.size() > 0))
+        {
+            for (auto it = fib_tmp.begin(); it != fib_tmp.end(); ++it)
+            {
+                // auto num =
+                double prob = it->second / max;
+                // 送信確率は10％以上
+                if (prob <= 0.1)
+                {
+                    prob = 0.1;
+                }
+                if (dist(rd) < prob)
+                {
+                    f_fib.insert(it->first);
+                    fib_tmp.erase(it);
+                    break;
+                }
+                fib_tmp.erase(it);
+            }
+        }
+        // 複数選んだFIBを返す
+        return f_fib;
+    };
+
+    // FIBの優先度が最大数に到達したら該当Content IDの優先度を全てスケールダウンする
+    void scaleDownPriority(const &std::string, ) // contentName contentName){
+        for (auto it = a_fib[contentName.getValue()].begin(); it != a_fib[contentName.getValue()].end(); ++it)
+    {
+        *it.second /= (MAX_PRIORITY * 10);
+        // スケールダウン時に優先度の低いFIBは削除
+        if (it.second < 0.1)
+            a_fib[contentName.getValue()].erase(it);
+    }
+
+public:
+    void saveForDynamic(FIBPair fibPair, std::string faceId, int hopCount) override
+    {
+        double priority = 0;
+        auto it = a_fib.find(fibPair.getContentName().getValue());
+        if (it != a_fib.end())
+        {
+            for (auto &x : a_fib[fibPair.getContentName().getValue()])
+            {
+                if (x.first == faceId)
+                {
+                    x.second += (1.0 / static_cast<double>(hopCount));
+                    if (x.second > MAX_PRIORITY)
+                        scaleDownPriority(fibPair.getContentName());
+                    return;
+                }
+            }
+            return;
+        }
+
+        // FIBのサイズが100を超えないように消す
+        while (m_maxSize <= a_fibManagement.size())
+        {
+            auto it = a_fib.find(a_fibManagement.front());
+            if (it != a_fib.end())
+                a_fib.erase(a_fibManagement.front());
+            a_fibManagement.pop();
+        }
+        a_fib[fibPair.getContentName().getValue()] = fibPair.getDestinationId().getValue();
+        for (auto &x : a_fib[fibPair.getContentName().getValue()])
+        {
+            x.second = (1.0 / static_cast<double>(hopCount));
+            // 優先度の初期値：1.0
+        }
+        a_fibManagement.push(fibPair.getContentName().getValue());
+    };
+
+    void remove(ContentName contentName) override
+    {
+        auto it = a_fib.find(contentName.getValue());
+        if (it != a_fib.end())
+            a_fib.erase(contentName.getValue());
+    };
+
+    bool find(ContentName contentName) override
+    {
+        auto it = a_fib.find(contentName.getValue());
+        return (it != a_fib.end());
+    };
+
+    // contentNameに一致するノードID（Face）を複数取得して返す
+    DestinationId get(ContentName contentName) override
+    {
+        auto it = a_fib.find(contentName.getValue());
+        if (it == a_fib.end())
+        {
+            return DestinationId({"NULL"});
+        }
+        else
+        {
+            // 動作を分けた
+            return DestinationId(pickupFibElement(a_fib[contentName.getValue()]));
+        }
+    };
+};
+
+#endif // INCLUDED_DIRECTEDDIFFUSION_FIB_REPOSITY_h_

--- a/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
+++ b/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
@@ -6,8 +6,8 @@
 #include <algorithm> // std::min
 #include <utility>
 #include <queue>
-#include <ctime>
 #include <random> //random
+#include <stdlib.h>
 
 #define THRESHOLD 5
 #define MAX_PRIORITY 100 // 優先度の最大値
@@ -43,8 +43,9 @@ private:
         if (nodeNum < 1)
             nodeNum = 1;
 
-        std::mt19937 rd(static_cast<unsigned int>(std::time(nullptr)));
-        std::uniform_int_distribution<double> dist(0.0, 1.0);
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<> dist(0.0, 1.0);
 
         // 戻り値用のfibリスト
         std::vector<std::pair<std::string, double>> fib_tmp = dest;
@@ -61,7 +62,7 @@ private:
                 {
                     prob = 0.1;
                 }
-                if (dist(rd) < prob)
+                if (dist(gen) < prob)
                 {
                     f_fib.insert(it->first);
                     fib_tmp.erase(it);

--- a/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
+++ b/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
@@ -7,7 +7,6 @@
 #include <utility>
 #include <queue>
 #include <random> //random
-#include <stdlib.h>
 
 #define THRESHOLD 5
 #define MAX_PRIORITY 100 // 優先度の最大値
@@ -91,6 +90,7 @@ public:
     // 1回ずつのみ処理
     void saveForDynamic(FIBPair fibPair, std::string faceId, int hopCount) override
     {
+        // FIBPairのDestinationIdはset型を使用しているが，setでは内容を書き換えられないためvectorに変換する
         // FIBPairの内容を1ノードずつFIBに登録するためのvectorを作成
         std::vector<std::pair<std::string, double>> tmp;
         for (auto &x : fibPair.getDestinationId().getValue())

--- a/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
+++ b/lib/gateways/yamamoto/DirectedDiffusionFIBRepository.hpp
@@ -10,19 +10,19 @@
 #include <random> //random
 
 #define THRESHOLD 5
-#define MAX_PRIORITY 100
-// 優先度の最大値
+#define MAX_PRIORITY 100 // 優先度の最大値
+#define MAX_DEG 4        // 次数の最大値
 
 class DirectedDiffusionFIBRepository : public FIBRepository
 {
 private:
-    // FIB本体はstring，doublepairのvectorを含むMAP
-    std::map<std::string, std::set<std::pair<std::string, double>>> a_fib;
+    // FIB本体はstring，doublepairのvectorを含むMAP．内部の値を変更できるvectorで宣言
+    std::map<std::string, std::vector<std::pair<std::string, double>>> a_fib;
     std::queue<std::string> a_fibManagement;
     int const m_maxSize = 100;
 
     // content IDと一致した配列を引数とし，複数の文字列型配列を戻り値とした関数．
-    std::set<std::string> pickupFibElement(std::set<std::pair<std::string, double>> dest)
+    std::set<std::string> pickupFibElement(std::vector<std::pair<std::string, double>> dest)
     {
         double max = 0.0;
         for (auto &x : dest)
@@ -47,7 +47,7 @@ private:
         std::uniform_int_distribution<double> dist(0.0, 1.0);
 
         // 戻り値用のfibリスト
-        std::set<std::pair<std::string, double>> fib_tmp = dest;
+        std::vector<std::pair<std::string, double>> fib_tmp = dest;
         std::set<std::string> f_fib;
 
         // 他に渡すFIBのリストを作成．計算量が増加しそうなので要改善
@@ -55,7 +55,6 @@ private:
         {
             for (auto it = fib_tmp.begin(); it != fib_tmp.end(); ++it)
             {
-                // auto num =
                 double prob = it->second / max;
                 // 送信確率は10％以上
                 if (prob <= 0.1)
@@ -76,30 +75,49 @@ private:
     };
 
     // FIBの優先度が最大数に到達したら該当Content IDの優先度を全てスケールダウンする
-    void scaleDownPriority(const &std::string, ) // contentName contentName){
-        for (auto it = a_fib[contentName.getValue()].begin(); it != a_fib[contentName.getValue()].end(); ++it)
+    void scaleDownPriority(std::string contentId)
     {
-        *it.second /= (MAX_PRIORITY * 10);
-        // スケールダウン時に優先度の低いFIBは削除
-        if (it.second < 0.1)
-            a_fib[contentName.getValue()].erase(it);
+        for (auto it = a_fib[contentId].begin(); it != a_fib[contentId].end(); ++it)
+        {
+            it->second /= (static_cast<double>(MAX_PRIORITY) * static_cast<double>(10));
+            // スケールダウン時に優先度の低いFIBは削除
+            if (it->second < 0.1)
+                a_fib[contentId].erase(it);
+        }
     }
 
 public:
+    // 1回ずつのみ処理
     void saveForDynamic(FIBPair fibPair, std::string faceId, int hopCount) override
     {
+        // FIBPairの内容を1ノードずつFIBに登録するためのvectorを作成
+        std::vector<std::pair<std::string, double>> tmp;
+        for (auto &x : fibPair.getDestinationId().getValue())
+        {
+            tmp.push_back(std::make_pair(x, 1.0 / static_cast<double>(hopCount)));
+        }
+
         double priority = 0;
         auto it = a_fib.find(fibPair.getContentName().getValue());
         if (it != a_fib.end())
         {
+            // もしvector内にfaceIdが存在しなければ引数のノードをFIBのVectorに追加する処理を後で作る
+            // 計算量オーダO^2なので下げる必要
             for (auto &x : a_fib[fibPair.getContentName().getValue()])
             {
-                if (x.first == faceId)
+                for (auto it = tmp.begin(); it != tmp.end(); ++it)
                 {
-                    x.second += (1.0 / static_cast<double>(hopCount));
-                    if (x.second > MAX_PRIORITY)
-                        scaleDownPriority(fibPair.getContentName());
-                    return;
+                    if (x.first == it->first)
+                    {
+                        x.second += (1.0 / static_cast<double>(hopCount));
+                        tmp.erase(it);
+                    }
+                }
+            }
+            if (tmp.size() > 0)
+            {
+                for(auto &x : tmp){
+                    a_fib[fibPair.getContentName().getValue()].push_back(x);
                 }
             }
             return;
@@ -113,11 +131,9 @@ public:
                 a_fib.erase(a_fibManagement.front());
             a_fibManagement.pop();
         }
-        a_fib[fibPair.getContentName().getValue()] = fibPair.getDestinationId().getValue();
-        for (auto &x : a_fib[fibPair.getContentName().getValue()])
-        {
-            x.second = (1.0 / static_cast<double>(hopCount));
-            // 優先度の初期値：1.0
+
+        for(auto &x : tmp){
+            a_fib[fibPair.getContentName().getValue()].push_back(x);
         }
         a_fibManagement.push(fibPair.getContentName().getValue());
     };

--- a/lib/interactor/node/NodeInteractor.hpp
+++ b/lib/interactor/node/NodeInteractor.hpp
@@ -16,7 +16,8 @@
 #include "model/ICN/FIBPair.hpp"
 #include "model/ICN/PITPair.hpp"
 #include "model/ICN/CSPair.hpp"
-#include "shonoshin/TwoStageLookupFIBRepository.hpp"
+//#include "shonoshin/TwoStageLookupFIBRepository.hpp"
+#include "yamamoto/DirectedDiffusionFIBRepository.hpp"
 #include "shonoshin/FIFOPITRepository.hpp"
 #include "shonoshin/FIFOCSRepository.hpp"
 // #include "node/NodePresenter.h"
@@ -33,7 +34,8 @@ private:
   // StubFIBRepository fibRepository;
   // StubPITRepository pitRepository;
   // StubCSRepository csRepository;
-  TwoStageLookupFIBRepository fibRepository;
+  //TwoStageLookupFIBRepository fibRepository;
+  DirectedDiffusionFIBRepository fibRepository;
   FIFOPITRepository pitRepository;
   FIFOCSRepository csRepository;
   // NodePresenter nodePresenter;
@@ -77,11 +79,11 @@ public:
       return outputData;
     }
     else
-    {
+    {/* //testuyou
       // save to PIT Table
       PITPair pitPair(contentName, DestinationId({senderId.getValue()}));
       pitRepository.save(pitPair);
-
+      */
       if (fibRepository.find(contentName))
       {
         // send Interest based on FIB Table
@@ -140,7 +142,7 @@ public:
     {
       // save to PIT Table
       FIBPair fibPair(contentName, DestinationId({senderId.getValue()}));
-      fibRepository.save(fibPair);
+      fibRepository.saveForDynamic(fibPair, senderId.getValue(), hopcount.getValue());
       // packet discard
       NodeOutputData outputData(
           std::string("NULL"),

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,11 +13,11 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
-upload_port = COM6
-monitor_port = COM6
+upload_port = COM11
+monitor_port = COM11
 lib_deps = painlessmesh/painlessMesh @ ^1.4.5
     ArduinoJson
-    ;arduinoUnity
+    arduinoUnity
     AsyncTCP
     TaskScheduler
     adafruit/Adafruit Unified Sensor @ ^1.1.4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,8 @@ void setup()
   mesh.onNewConnection(&newConnectionCallback);
   mesh.onChangedConnections(&changedConnectionCallback);
   mesh.onNodeTimeAdjusted(&nodeTimeAdjustedCallback);
+  
+  Serial.printf("%u\n", mesh.getNodeId());
 }
 
 void loop()


### PR DESCRIPTION
ビルド可能に修正
・乱数：random_deviceを使用
・faceと優先度の扱い：setでは内部の変更ができないため，set↔vectorを変換
