### PR TITLE
feat(build): add support for ESP32-S3-DevKitC-1-N8R8(#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ pio run -e perf    -t upload
 pio run -e release -t upload
 
 # ESP32-S3-DevKitC-1-N8R8 向け
+pio run -e normal_s3 -t uploadfs
+
 pio run -e normal_s3  -t upload
 pio run -e perf_s3    -t upload
 pio run -e release_s3 -t upload

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ data/
 | `perf` | ログ最小化（WARN中心）、perf 機能を有効化 |
 | `release` | ログ最小化（WARN中心）、perf 機能は無効 |
 
+利用可能な PlatformIO 環境は以下のとおりです。
+
+| Environment | Board | 用途 |
+|-------------|-------|------|
+| `normal` / `perf` / `release` | `ESP32-DevKitC-32E` | センサノード用 |
+| `normal_s3` / `perf_s3` / `release_s3` | `ESP32-S3-DevKitC-1-N8R8` | クラスタヘッド用 |
+
 ### ビルド・書き込み
 
 ```bash
@@ -142,9 +149,34 @@ pio run -e normal -t uploadfs
 pio run -e normal  -t upload
 pio run -e perf    -t upload
 pio run -e release -t upload
+
+# ESP32-S3-DevKitC-1-N8R8 向け
+pio run -e normal_s3  -t upload
+pio run -e perf_s3    -t upload
+pio run -e release_s3 -t upload
 ```
 
 `upload_port` は `platformio.ini` か CLI の `--upload-port` で指定してください。
+
+CLI で一時的に上書きする場合の例:
+
+```bash
+pio run -e normal_s3 -t upload --upload-port COM7
+pio run -e normal_s3 -t monitor --monitor-port COM7
+```
+
+ESP32-S3-DevKitC-1-N8R8 で書き込みに失敗する場合は、以下を順に確認してください。
+
+- USB ケーブルの挿し直し後に COM ポート番号が変わっていないか
+- `platformio.ini` の `upload_port` / `monitor_port` と実機のポートが一致しているか
+- 書き込み開始時に `BOOT` を押しながら `RESET` を短く押し、その後 `BOOT` を離してダウンロードモードに入れられるか
+- それでも不安定な場合は `--upload-port` に加えて `--upload-speed 115200` を指定して再試行する
+
+S3 のシリアルモニタ例:
+
+```bash
+pio run -e normal_s3 -t monitor
+```
 
 ### perf コマンドについて
 
@@ -202,5 +234,8 @@ CI では実機がないため、`upload` / `uploadfs` は実行しません。
 pio run -e normal
 pio run -e perf
 pio run -e release
+pio run -e normal_s3
+pio run -e perf_s3
+pio run -e release_s3
 pio check -e normal
 ```

--- a/boards/esp32-s3-devkitc-1-n8r8.json
+++ b/boards/esp32-s3-devkitc-1-n8r8.json
@@ -1,0 +1,54 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "psram_type": "opi",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-S3-DevKitC-1-N8R8 (8 MB QIO Flash, 8 MB OPI PSRAM)",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,3 +47,22 @@ build_flags =
 build_flags =
     ${env.build_flags}
     -DICSN_BUILD_PROFILE=3
+
+[env:normal_s3]
+board = esp32-s3-devkitc-1-n8r8
+build_flags =
+    ${env.build_flags}
+    -DICSN_BUILD_PROFILE=1
+
+[env:perf_s3]
+board = esp32-s3-devkitc-1-n8r8
+build_flags =
+    ${env.build_flags}
+    -DICSN_BUILD_PROFILE=2
+    -DPERFORMANCE_MEASURE
+
+[env:release_s3]
+board = esp32-s3-devkitc-1-n8r8
+build_flags =
+    ${env.build_flags}
+    -DICSN_BUILD_PROFILE=3


### PR DESCRIPTION
# 概要

- ESP32-S3ようにbuild環境を整備しました．

Closes #52 

# 主な変更点

- boards/配下にESPのS3ようのマニフェストを作成

# レビュアーが注視すべき点

- 

# 確認

- [x] CIで検出できない範囲を必要に応じて手動確認しました．
- [x] 機密情報（トークン等）を含んでいません．