### PR TITLE
ESP-NOWとICSNのセキュリティ設定を分離しCCMP鍵管理を有効化(#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ ESP32を使用したICSN（Interest-Centric Sensor Network）の実装です。
 
 ESP-NOW の WPA2 ベース暗号化を有効化します。
 
-- **PMK (Primary Master Key)**: 全ピア共通のグローバルキー。`config.json` の `PMK` フィールド（32 文字 hex）で設定します。
-- **LMK (Local Master Key)**: ピアごとの暗号化キー。`config.json` の `LMK` フィールドをデフォルト値として使用し、ピア登録時に適用します。
+- **PMK (Primary Master Key)**: `esp_now_security.pmk`（32 文字 hex）を `esp_now_set_pmk()` へ設定します。
+- **LMK (Local Master Key)**: `esp_now_security.peers[].lmk` または `esp_now_security.default_lmk` を peer 登録時に `peer.lmk` へ設定し、`peer.encrypt = true` でCCMPを有効化します。
 
 ### HMAC-SHA256 による送信元認証
 
-各パケットには HMAC-SHA256 ダイジェスト（32 バイト）が付加されます。受信側は LMK を鍵として検証し、改ざんを検出します。
+各パケットには HMAC-SHA256 ダイジェスト（32 バイト）が付加されます。受信側は `icsn_security` の鍵を使って検証し、改ざんを検出します。
 
 ### リプレイ攻撃対策（送受信カウンタ）
 
 `PeerCounterManager` がピアごとに TX/RX カウンタを管理します。受信パケットのカウンタが既知の値以下の場合は破棄することで、録画・再送攻撃を防ぎます。
 
-> **注意**: PMK・LMK はデフォルト値のままでは安全ではありません。本番環境では必ず固有の値に変更してください。
+> **注意**: PMK・LMK・HMAC鍵はデフォルト値のままでは安全ではありません。本番環境では必ず固有の値に変更してください。
 
 ## 依存方向のルール
 
@@ -86,9 +86,17 @@ PlatformIO の pre-script（`scripts/generate_node_profile.py`）が、ロール
 {
   "MAX_VIRTUAL_DEPTH": 5,
   "HOP_COUNT_THRESHOLD": 10,
-  "PMK": "0123456789abcdef0123456789abcdef",
-  "LMK": "fedcba9876543210fedcba9876543210",
-  "peers": [],
+  "esp_now_security": {
+    "enabled": true,
+    "pmk": "0123456789abcdef0123456789abcdef",
+    "default_lmk": "fedcba9876543210fedcba9876543210",
+    "peers": []
+  },
+  "icsn_security": {
+    "hmac_enabled": true,
+    "default_hmac_key": "fedcba9876543210fedcba9876543210",
+    "peers": []
+  },
   "fib_init": []
 }
 ```
@@ -97,9 +105,13 @@ PlatformIO の pre-script（`scripts/generate_node_profile.py`）が、ロール
 |-----------|------|
 | `MAX_VIRTUAL_DEPTH` | 仮想深さの上限（ルーティング制御用） |
 | `HOP_COUNT_THRESHOLD` | ホップカウントの上限（ループ抑制） |
-| `PMK` | ESP-NOW Global PMK（32 文字 hex = 16 バイト）。全ピア共通の暗号化マスターキー |
-| `LMK` | ESP-NOW Local Master Key（32 文字 hex = 16 バイト）。ピア固有暗号化キーのデフォルト値 |
-| `peers` | 起動時に登録するピアの MAC アドレス一覧（省略可） |
+| `esp_now_security.enabled` | ESP-NOW CCMP暗号化を有効化するフラグ |
+| `esp_now_security.pmk` | ESP-NOW Global PMK（32 文字 hex = 16 バイト） |
+| `esp_now_security.default_lmk` | ESP-NOW 用のデフォルト LMK（32 文字 hex = 16 バイト） |
+| `esp_now_security.peers[].lmk` | ESP-NOW 用の peer 固有 LMK |
+| `icsn_security.hmac_enabled` | ICSN パケットの HMAC 検証/付与を有効化するフラグ |
+| `icsn_security.default_hmac_key` | ICSN 用のデフォルト HMAC 鍵（32 文字 hex = 16 バイト） |
+| `icsn_security.peers[].hmac_key` | ICSN 用の peer 固有 HMAC 鍵 |
 | `fib_init` | 起動時に投入する FIB 初期エントリ一覧（省略可） |
 
 ## ビルド環境

--- a/data/config.json
+++ b/data/config.json
@@ -1,8 +1,16 @@
 {
   "MAX_VIRTUAL_DEPTH": 5,
   "HOP_COUNT_THRESHOLD": 10,
-  "PMK": "0123456789abcdef0123456789abcdef",
-  "LMK": "fedcba9876543210fedcba9876543210",
-  "peers": [],
+  "esp_now_security": {
+    "enabled": true,
+    "pmk": "0123456789abcdef0123456789abcdef",
+    "default_lmk": "fedcba9876543210fedcba9876543210",
+    "peers": []
+  },
+  "icsn_security": {
+    "hmac_enabled": true,
+    "default_hmac_key": "fedcba9876543210fedcba9876543210",
+    "peers": []
+  },
   "fib_init": []
 }

--- a/lib/ICSN/config/Config.cpp
+++ b/lib/ICSN/config/Config.cpp
@@ -1,4 +1,5 @@
 #include "Config.hpp"
+#include "BuildProfile.hpp"
 #include <ArduinoJson.h>
 #include <LittleFS.h>
 
@@ -43,6 +44,112 @@ static bool macStringToBytes(const char* macStr, uint8_t out[6]) {
   return true;
 }
 
+static void resetSecurityConfig() {
+  systemConfig.espNowEncryptionEnabled = false;
+  systemConfig.espNowPmkConfigured = false;
+  memset(systemConfig.espNowPmk, 0, sizeof(systemConfig.espNowPmk));
+
+  systemConfig.espNowDefaultLmkConfigured = false;
+  memset(systemConfig.espNowDefaultLmk, 0, sizeof(systemConfig.espNowDefaultLmk));
+  systemConfig.espNowPeerLmkCount = 0;
+  memset(systemConfig.espNowPeerLmkEntries, 0, sizeof(systemConfig.espNowPeerLmkEntries));
+
+  systemConfig.hmacAuthenticationEnabled = false;
+  systemConfig.hmacDefaultKeyConfigured = false;
+  memset(systemConfig.hmacDefaultKey, 0, sizeof(systemConfig.hmacDefaultKey));
+  systemConfig.hmacPeerKeyCount = 0;
+  memset(systemConfig.hmacPeerKeyEntries, 0, sizeof(systemConfig.hmacPeerKeyEntries));
+}
+
+static size_t loadPeerKeys(JsonVariantConst peersNode, const char* keyName, PeerKeyConfig* outEntries,
+                           size_t maxEntries) {
+  if (!peersNode.is<JsonArrayConst>() || outEntries == nullptr || keyName == nullptr) {
+    return 0;
+  }
+
+  size_t count = 0;
+  JsonArrayConst peers = peersNode.as<JsonArrayConst>();
+  for (JsonObjectConst peer : peers) {
+    if (count >= maxEntries) {
+      break;
+    }
+
+    const char* macStr = peer["mac"] | "";
+    const char* keyStr = peer[keyName] | "";
+
+    PeerKeyConfig& entry = outEntries[count];
+    if (macStringToBytes(macStr, entry.mac) && hexStringToBytes(keyStr, entry.key, ESP_NOW_LMK_LEN)) {
+      entry.valid = true;
+      count++;
+    }
+  }
+
+  return count;
+}
+
+static void loadLegacySecurityConfig(const JsonDocument& doc) {
+  const char* pmkStr = doc["PMK"] | "";
+  const char* lmkStr = doc["LMK"] | "";
+
+  const bool pmkValid = hexStringToBytes(pmkStr, systemConfig.espNowPmk, ESP_NOW_PMK_LEN);
+  const bool lmkValid = hexStringToBytes(lmkStr, systemConfig.espNowDefaultLmk, ESP_NOW_LMK_LEN);
+
+  systemConfig.espNowPmkConfigured = pmkValid;
+  systemConfig.espNowDefaultLmkConfigured = lmkValid;
+  systemConfig.espNowEncryptionEnabled = pmkValid;
+
+  if (lmkValid) {
+    memcpy(systemConfig.hmacDefaultKey, systemConfig.espNowDefaultLmk, ICSN_HMAC_KEY_LEN);
+    systemConfig.hmacDefaultKeyConfigured = true;
+    systemConfig.hmacAuthenticationEnabled = true;
+  }
+
+  systemConfig.espNowPeerLmkCount =
+      loadPeerKeys(doc["peers"], "lmk", systemConfig.espNowPeerLmkEntries, MAX_PEER_KEY_ENTRIES);
+
+  systemConfig.hmacPeerKeyCount =
+      loadPeerKeys(doc["peers"], "lmk", systemConfig.hmacPeerKeyEntries, MAX_PEER_KEY_ENTRIES);
+
+  if (pmkValid || lmkValid || systemConfig.espNowPeerLmkCount > 0) {
+    LOG_WARN("[SECURITY] Deprecated config detected. Use esp_now_security / icsn_security.");
+  }
+}
+
+static void loadSeparatedSecurityConfig(const JsonDocument& doc) {
+  JsonObjectConst espNowSecurity = doc["esp_now_security"].as<JsonObjectConst>();
+  JsonObjectConst icsnSecurity = doc["icsn_security"].as<JsonObjectConst>();
+
+  const bool espNowEnabledFlag = espNowSecurity["enabled"] | false;
+  const char* pmkStr = espNowSecurity["pmk"] | "";
+  const char* defaultLmkStr = espNowSecurity["default_lmk"] | "";
+
+  systemConfig.espNowPmkConfigured = hexStringToBytes(pmkStr, systemConfig.espNowPmk, ESP_NOW_PMK_LEN);
+  systemConfig.espNowDefaultLmkConfigured =
+      hexStringToBytes(defaultLmkStr, systemConfig.espNowDefaultLmk, ESP_NOW_LMK_LEN);
+  systemConfig.espNowPeerLmkCount = loadPeerKeys(espNowSecurity["peers"], "lmk",
+                                                 systemConfig.espNowPeerLmkEntries,
+                                                 MAX_PEER_KEY_ENTRIES);
+
+  systemConfig.espNowEncryptionEnabled = espNowEnabledFlag && systemConfig.espNowPmkConfigured;
+  if (espNowEnabledFlag && !systemConfig.espNowPmkConfigured) {
+    LOG_WARN("[SECURITY] esp_now_security.enabled is true but PMK is invalid or missing.");
+  }
+
+  const bool hmacEnabledFlag = icsnSecurity["hmac_enabled"] | false;
+  const char* defaultHmacKeyStr = icsnSecurity["default_hmac_key"] | "";
+  systemConfig.hmacDefaultKeyConfigured =
+      hexStringToBytes(defaultHmacKeyStr, systemConfig.hmacDefaultKey, ICSN_HMAC_KEY_LEN);
+  systemConfig.hmacPeerKeyCount = loadPeerKeys(icsnSecurity["peers"], "hmac_key",
+                                               systemConfig.hmacPeerKeyEntries,
+                                               MAX_PEER_KEY_ENTRIES);
+
+  systemConfig.hmacAuthenticationEnabled =
+      hmacEnabledFlag && (systemConfig.hmacDefaultKeyConfigured || systemConfig.hmacPeerKeyCount > 0);
+  if (hmacEnabledFlag && !systemConfig.hmacAuthenticationEnabled) {
+    LOG_WARN("[SECURITY] icsn_security.hmac_enabled is true but HMAC key is missing.");
+  }
+}
+
 bool loadSystemConfig(const char* path) {
   if (!LittleFS.begin())
     return false;
@@ -59,37 +166,11 @@ bool loadSystemConfig(const char* path) {
   systemConfig.maxVirtualDepth = doc["MAX_VIRTUAL_DEPTH"] | 5;
   systemConfig.hopCountThreshold = doc["HOP_COUNT_THRESHOLD"] | 10;
 
-  // セキュリティ設定の読み込み
-  const char* pmkStr = doc["PMK"] | "";
-  const char* lmkStr = doc["LMK"] | "";
-
-  if (strlen(pmkStr) == ESP_NOW_PMK_LEN * 2 && strlen(lmkStr) == ESP_NOW_LMK_LEN * 2) {
-    if (hexStringToBytes(pmkStr, systemConfig.pmk, ESP_NOW_PMK_LEN) &&
-        hexStringToBytes(lmkStr, systemConfig.lmk, ESP_NOW_LMK_LEN)) {
-      systemConfig.encryptionEnabled = true;
-    }
-  }
-
-  // ピア固有LMK設定の読み込み
-  systemConfig.peerLmkCount = 0;
-  memset(systemConfig.peerLmkEntries, 0, sizeof(systemConfig.peerLmkEntries));
-
-  if (doc.containsKey("peers")) {
-    JsonArray peers = doc["peers"].as<JsonArray>();
-    for (JsonObject peer : peers) {
-      if (systemConfig.peerLmkCount >= MAX_PEER_LMK_ENTRIES)
-        break;
-
-      const char* macStr = peer["mac"] | "";
-      const char* peerLmk = peer["lmk"] | "";
-
-      PeerLMKConfig& entry = systemConfig.peerLmkEntries[systemConfig.peerLmkCount];
-      if (macStringToBytes(macStr, entry.mac) &&
-          hexStringToBytes(peerLmk, entry.lmk, ESP_NOW_LMK_LEN)) {
-        entry.valid = true;
-        systemConfig.peerLmkCount++;
-      }
-    }
+  resetSecurityConfig();
+  if (doc.containsKey("esp_now_security") || doc.containsKey("icsn_security")) {
+    loadSeparatedSecurityConfig(doc);
+  } else {
+    loadLegacySecurityConfig(doc);
   }
 
   // FIB初期エントリの読み込み

--- a/lib/ICSN/config/Config.cpp
+++ b/lib/ICSN/config/Config.cpp
@@ -61,7 +61,9 @@ static void resetSecurityConfig() {
   memset(systemConfig.hmacPeerKeyEntries, 0, sizeof(systemConfig.hmacPeerKeyEntries));
 }
 
-static size_t loadPeerKeys(JsonVariantConst peersNode, const char* keyName, PeerKeyConfig* outEntries,
+static size_t loadPeerKeys(JsonVariantConst peersNode,
+                           const char* keyName,
+                           PeerKeyConfig* outEntries,
                            size_t maxEntries) {
   if (!peersNode.is<JsonArrayConst>() || outEntries == nullptr || keyName == nullptr) {
     return 0;
@@ -78,7 +80,8 @@ static size_t loadPeerKeys(JsonVariantConst peersNode, const char* keyName, Peer
     const char* keyStr = peer[keyName] | "";
 
     PeerKeyConfig& entry = outEntries[count];
-    if (macStringToBytes(macStr, entry.mac) && hexStringToBytes(keyStr, entry.key, ESP_NOW_LMK_LEN)) {
+    if (macStringToBytes(macStr, entry.mac) &&
+      hexStringToBytes(keyStr, entry.key, ESP_NOW_LMK_LEN)) {
       entry.valid = true;
       count++;
     }
@@ -123,12 +126,15 @@ static void loadSeparatedSecurityConfig(const JsonDocument& doc) {
   const char* pmkStr = espNowSecurity["pmk"] | "";
   const char* defaultLmkStr = espNowSecurity["default_lmk"] | "";
 
-  systemConfig.espNowPmkConfigured = hexStringToBytes(pmkStr, systemConfig.espNowPmk, ESP_NOW_PMK_LEN);
+  systemConfig.espNowPmkConfigured =
+      hexStringToBytes(pmkStr, systemConfig.espNowPmk, ESP_NOW_PMK_LEN);
   systemConfig.espNowDefaultLmkConfigured =
       hexStringToBytes(defaultLmkStr, systemConfig.espNowDefaultLmk, ESP_NOW_LMK_LEN);
-  systemConfig.espNowPeerLmkCount = loadPeerKeys(espNowSecurity["peers"], "lmk",
-                                                 systemConfig.espNowPeerLmkEntries,
-                                                 MAX_PEER_KEY_ENTRIES);
+  systemConfig.espNowPeerLmkCount =
+      loadPeerKeys(espNowSecurity["peers"],
+                   "lmk",
+                   systemConfig.espNowPeerLmkEntries,
+                   MAX_PEER_KEY_ENTRIES);
 
   systemConfig.espNowEncryptionEnabled = espNowEnabledFlag && systemConfig.espNowPmkConfigured;
   if (espNowEnabledFlag && !systemConfig.espNowPmkConfigured) {
@@ -139,12 +145,15 @@ static void loadSeparatedSecurityConfig(const JsonDocument& doc) {
   const char* defaultHmacKeyStr = icsnSecurity["default_hmac_key"] | "";
   systemConfig.hmacDefaultKeyConfigured =
       hexStringToBytes(defaultHmacKeyStr, systemConfig.hmacDefaultKey, ICSN_HMAC_KEY_LEN);
-  systemConfig.hmacPeerKeyCount = loadPeerKeys(icsnSecurity["peers"], "hmac_key",
-                                               systemConfig.hmacPeerKeyEntries,
-                                               MAX_PEER_KEY_ENTRIES);
+  systemConfig.hmacPeerKeyCount =
+      loadPeerKeys(icsnSecurity["peers"],
+                   "hmac_key",
+                   systemConfig.hmacPeerKeyEntries,
+                   MAX_PEER_KEY_ENTRIES);
 
-  systemConfig.hmacAuthenticationEnabled =
-      hmacEnabledFlag && (systemConfig.hmacDefaultKeyConfigured || systemConfig.hmacPeerKeyCount > 0);
+  systemConfig.hmacAuthenticationEnabled = hmacEnabledFlag &&
+                                           (systemConfig.hmacDefaultKeyConfigured ||
+                                            systemConfig.hmacPeerKeyCount > 0);
   if (hmacEnabledFlag && !systemConfig.hmacAuthenticationEnabled) {
     LOG_WARN("[SECURITY] icsn_security.hmac_enabled is true but HMAC key is missing.");
   }

--- a/lib/ICSN/config/Config.cpp
+++ b/lib/ICSN/config/Config.cpp
@@ -61,10 +61,8 @@ static void resetSecurityConfig() {
   memset(systemConfig.hmacPeerKeyEntries, 0, sizeof(systemConfig.hmacPeerKeyEntries));
 }
 
-static size_t loadPeerKeys(JsonVariantConst peersNode,
-                           const char* keyName,
-                           PeerKeyConfig* outEntries,
-                           size_t maxEntries) {
+static size_t loadPeerKeys(JsonVariantConst peersNode, const char* keyName,
+                           PeerKeyConfig* outEntries, size_t maxEntries) {
   if (!peersNode.is<JsonArrayConst>() || outEntries == nullptr || keyName == nullptr) {
     return 0;
   }
@@ -81,7 +79,7 @@ static size_t loadPeerKeys(JsonVariantConst peersNode,
 
     PeerKeyConfig& entry = outEntries[count];
     if (macStringToBytes(macStr, entry.mac) &&
-      hexStringToBytes(keyStr, entry.key, ESP_NOW_LMK_LEN)) {
+        hexStringToBytes(keyStr, entry.key, ESP_NOW_LMK_LEN)) {
       entry.valid = true;
       count++;
     }
@@ -130,11 +128,8 @@ static void loadSeparatedSecurityConfig(const JsonDocument& doc) {
       hexStringToBytes(pmkStr, systemConfig.espNowPmk, ESP_NOW_PMK_LEN);
   systemConfig.espNowDefaultLmkConfigured =
       hexStringToBytes(defaultLmkStr, systemConfig.espNowDefaultLmk, ESP_NOW_LMK_LEN);
-  systemConfig.espNowPeerLmkCount =
-      loadPeerKeys(espNowSecurity["peers"],
-                   "lmk",
-                   systemConfig.espNowPeerLmkEntries,
-                   MAX_PEER_KEY_ENTRIES);
+  systemConfig.espNowPeerLmkCount = loadPeerKeys(
+      espNowSecurity["peers"], "lmk", systemConfig.espNowPeerLmkEntries, MAX_PEER_KEY_ENTRIES);
 
   systemConfig.espNowEncryptionEnabled = espNowEnabledFlag && systemConfig.espNowPmkConfigured;
   if (espNowEnabledFlag && !systemConfig.espNowPmkConfigured) {
@@ -145,15 +140,12 @@ static void loadSeparatedSecurityConfig(const JsonDocument& doc) {
   const char* defaultHmacKeyStr = icsnSecurity["default_hmac_key"] | "";
   systemConfig.hmacDefaultKeyConfigured =
       hexStringToBytes(defaultHmacKeyStr, systemConfig.hmacDefaultKey, ICSN_HMAC_KEY_LEN);
-  systemConfig.hmacPeerKeyCount =
-      loadPeerKeys(icsnSecurity["peers"],
-                   "hmac_key",
-                   systemConfig.hmacPeerKeyEntries,
-                   MAX_PEER_KEY_ENTRIES);
+  systemConfig.hmacPeerKeyCount = loadPeerKeys(
+      icsnSecurity["peers"], "hmac_key", systemConfig.hmacPeerKeyEntries, MAX_PEER_KEY_ENTRIES);
 
-  systemConfig.hmacAuthenticationEnabled = hmacEnabledFlag &&
-                                           (systemConfig.hmacDefaultKeyConfigured ||
-                                            systemConfig.hmacPeerKeyCount > 0);
+  systemConfig.hmacAuthenticationEnabled =
+      hmacEnabledFlag &&
+      (systemConfig.hmacDefaultKeyConfigured || systemConfig.hmacPeerKeyCount > 0);
   if (hmacEnabledFlag && !systemConfig.hmacAuthenticationEnabled) {
     LOG_WARN("[SECURITY] icsn_security.hmac_enabled is true but HMAC key is missing.");
   }

--- a/lib/ICSN/config/Config.hpp
+++ b/lib/ICSN/config/Config.hpp
@@ -22,8 +22,8 @@ constexpr size_t MAX_PEER_KEY_ENTRIES = 20;
 /// @brief FIB初期エントリ（起動時にFIBへ投入するルーティング設定）
 struct FibInitEntry {
   char contentName[64]; ///< コンテンツ名プレフィックス（例: "/iot/buildingA/room101"）
-  char nextHopMac[18]; ///< 次ホップMACアドレス（小文字コロン区切り、例: "cc:7b:5c:9a:f3:ac"）
-  bool valid; ///< エントリが有効かどうか
+  char nextHopMac[18];  ///< 次ホップMACアドレス（小文字コロン区切り、例: "cc:7b:5c:9a:f3:ac"）
+  bool valid;           ///< エントリが有効かどうか
 };
 
 /// @brief FIB初期エントリの最大数

--- a/lib/ICSN/config/Config.hpp
+++ b/lib/ICSN/config/Config.hpp
@@ -22,8 +22,10 @@ constexpr size_t MAX_PEER_KEY_ENTRIES = 20;
 /// @brief FIB初期エントリ（起動時にFIBへ投入するルーティング設定）
 struct FibInitEntry {
   char contentName[64]; ///< コンテンツ名プレフィックス（例: "/iot/buildingA/room101"）
-  char nextHopMac[18];  ///< 次ホップMACアドレス（小文字コロン区切り、例: "cc:7b:5c:9a:f3:ac"）
-  bool valid;           ///< エントリが有効かどうか
+  /// 次ホップMACアドレス（小文字コロン区切り、例: "cc:7b:5c:9a:f3:ac"）
+  char nextHopMac[18];
+  /// エントリが有効かどうか
+  bool valid;
 };
 
 /// @brief FIB初期エントリの最大数

--- a/lib/ICSN/config/Config.hpp
+++ b/lib/ICSN/config/Config.hpp
@@ -7,16 +7,17 @@
 // セキュリティ関連定数
 constexpr size_t ESP_NOW_PMK_LEN = 16;
 constexpr size_t ESP_NOW_LMK_LEN = 16;
+constexpr size_t ICSN_HMAC_KEY_LEN = 16;
 
-/// @brief ピア固有LMK設定エントリ
-struct PeerLMKConfig {
+/// @brief ピア固有キー設定エントリ
+struct PeerKeyConfig {
   uint8_t mac[6];               ///< ピアのMACアドレス
-  uint8_t lmk[ESP_NOW_LMK_LEN]; ///< このピア向けのLocal Master Key
+  uint8_t key[ESP_NOW_LMK_LEN]; ///< このピア向けの16バイト鍵
   bool valid;                   ///< エントリが有効かどうか
 };
 
-/// @brief ピア固有LMKの最大登録数
-constexpr size_t MAX_PEER_LMK_ENTRIES = 20;
+/// @brief ピア固有鍵の最大登録数
+constexpr size_t MAX_PEER_KEY_ENTRIES = 20;
 
 /// @brief FIB初期エントリ（起動時にFIBへ投入するルーティング設定）
 struct FibInitEntry {
@@ -32,14 +33,21 @@ struct SystemConfig {
   int maxVirtualDepth = 5;
   int hopCountThreshold = 10;
 
-  // セキュリティ設定
-  uint8_t pmk[ESP_NOW_PMK_LEN] = {0}; // Primary Master Key
-  uint8_t lmk[ESP_NOW_LMK_LEN] = {0}; // グローバルLocal Master Key（ピア固有LMK未設定時に使用）
-  bool encryptionEnabled = false;
+  // ESP-NOW CCMP 設定
+  bool espNowEncryptionEnabled = false;
+  uint8_t espNowPmk[ESP_NOW_PMK_LEN] = {0};
+  bool espNowPmkConfigured = false;
+  uint8_t espNowDefaultLmk[ESP_NOW_LMK_LEN] = {0};
+  bool espNowDefaultLmkConfigured = false;
+  PeerKeyConfig espNowPeerLmkEntries[MAX_PEER_KEY_ENTRIES];
+  size_t espNowPeerLmkCount = 0;
 
-  // ピア固有LMK設定
-  PeerLMKConfig peerLmkEntries[MAX_PEER_LMK_ENTRIES];
-  size_t peerLmkCount = 0;
+  // ICSN HMAC 設定
+  bool hmacAuthenticationEnabled = false;
+  uint8_t hmacDefaultKey[ICSN_HMAC_KEY_LEN] = {0};
+  bool hmacDefaultKeyConfigured = false;
+  PeerKeyConfig hmacPeerKeyEntries[MAX_PEER_KEY_ENTRIES];
+  size_t hmacPeerKeyCount = 0;
 
   // FIB初期エントリ（テスト用ブランチで多段経路を事前設定するために使用）
   FibInitEntry fibInitEntries[MAX_FIB_INIT_ENTRIES];

--- a/lib/ICSN/controller/ESP-NOWController.cpp
+++ b/lib/ICSN/controller/ESP-NOWController.cpp
@@ -22,19 +22,23 @@ bool ESP_NOWController::loadAndApplyConfig(const char* configPath) {
     return false;
   }
 
-  encryptionEnabled = systemConfig.encryptionEnabled;
+  espNowEncryptionEnabled = systemConfig.espNowEncryptionEnabled;
+  hmacAuthenticationEnabled = systemConfig.hmacAuthenticationEnabled;
   memset(pmk, 0, sizeof(pmk));
 
-  if (encryptionEnabled) {
-    memcpy(pmk, systemConfig.pmk, sizeof(pmk));
-    setGlobalLMK(systemConfig.lmk);
-    LOG_INFO("[SECURITY] Global LMK configured for HMAC");
+  if (espNowEncryptionEnabled && systemConfig.espNowPmkConfigured) {
+    memcpy(pmk, systemConfig.espNowPmk, sizeof(pmk));
   }
 
-  for (size_t i = 0; i < systemConfig.peerLmkCount; i++) {
-    const PeerLMKConfig& entry = systemConfig.peerLmkEntries[i];
+  if (hmacAuthenticationEnabled && systemConfig.hmacDefaultKeyConfigured) {
+    setGlobalLMK(systemConfig.hmacDefaultKey);
+    LOG_INFO("[SECURITY] ICSN HMAC default key configured");
+  }
+
+  for (size_t i = 0; i < systemConfig.hmacPeerKeyCount; i++) {
+    const PeerKeyConfig& entry = systemConfig.hmacPeerKeyEntries[i];
     if (entry.valid) {
-      setPeerLMK(entry.mac, entry.lmk);
+      setPeerLMK(entry.mac, entry.key);
     }
   }
 
@@ -50,7 +54,7 @@ bool ESP_NOWController::loadAndApplyConfig(const char* configPath) {
 }
 
 bool ESP_NOWController::copyPMK(uint8_t* outPmk, size_t outLen) const {
-  if (outPmk == nullptr || outLen < sizeof(pmk) || !encryptionEnabled) {
+  if (outPmk == nullptr || outLen < sizeof(pmk) || !espNowEncryptionEnabled) {
     return false;
   }
 
@@ -87,7 +91,11 @@ bool ESP_NOWController::initializeCommunication(const char* configPath, uint8_t 
       LOG_WARN("Failed to set PMK");
       return false;
     }
-    LOG_INFO("ESP-NOW encryption enabled (PMK/LMK configured)");
+    LOG_INFO("[SECURITY] ESP-NOW PMK configured");
+  }
+
+  if (hmacAuthenticationEnabled) {
+    LOG_INFO("[SECURITY] ICSN HMAC authentication enabled");
   }
 
   esp_err_t macErr = esp_wifi_get_mac(WIFI_IF_STA, myMac);
@@ -104,20 +112,34 @@ bool ESP_NOWController::initializeCommunication(const char* configPath, uint8_t 
   return true;
 }
 
-void ESP_NOWController::registerPeerIfNeeded(const uint8_t mac[6]) {
+bool ESP_NOWController::registerPeerIfNeeded(const uint8_t mac[6]) {
   if (mac == nullptr || esp_now_is_peer_exist(mac)) {
-    return;
+    return true;
   }
 
   esp_now_peer_info_t peer = {};
   memcpy(peer.peer_addr, mac, 6);
   peer.channel = 0;
   peer.ifidx = WIFI_IF_STA;
-  peer.encrypt = false;
+
+  if (espNowEncryptionEnabled && !isBroadcastOrMulticast(mac)) {
+    const uint8_t* lmk = resolveEspNowLmk(mac);
+    if (lmk == nullptr) {
+      LOG_WARN("[SECURITY] LMK is missing for encrypted peer");
+      return false;
+    }
+    memcpy(peer.lmk, lmk, PEER_LMK_LEN);
+    peer.encrypt = true;
+  } else {
+    peer.encrypt = false;
+  }
 
   if (esp_now_add_peer(&peer) != ESP_OK) {
     LOG_WARN("[PEER] Failed to register peer");
+    return false;
   }
+
+  return true;
 }
 
 bool ESP_NOWController::sendPacketToAddresses(const ESP_NOWControlData& data) {
@@ -133,7 +155,10 @@ bool ESP_NOWController::sendPacketToAddresses(const ESP_NOWControlData& data) {
       continue;
     }
 
-    registerPeerIfNeeded(addr.data());
+    if (!registerPeerIfNeeded(addr.data())) {
+      LOG_WARN("[PEER] Packet dropped due to peer registration failure");
+      continue;
+    }
 
     esp_err_t err =
         esp_now_send(addr.data(), reinterpret_cast<const uint8_t*>(&packet), sizeof(packet));
@@ -199,7 +224,9 @@ bool ESP_NOWController::processReceivedPacket(const uint8_t myMac[6], const uint
     return false;
   }
 
-  registerPeerIfNeeded(senderMac);
+  if (!registerPeerIfNeeded(senderMac)) {
+    return false;
+  }
 
   CommunicationData receivedPacket = {};
   memcpy(&receivedPacket, data, sizeof(receivedPacket));
@@ -214,7 +241,7 @@ bool ESP_NOWController::processReceivedPacket(const uint8_t myMac[6], const uint
   }
 #endif
 
-  out.securityCheckRequired = true;
+  out.securityCheckRequired = hmacAuthenticationEnabled;
   if (out.securityCheckRequired) {
 #if ICSN_PERF_ENABLED
     if (out.isInterest) {
@@ -394,6 +421,10 @@ bool ESP_NOWController::buildPacketForAddress(const uint8_t txAddress[6],
 
 bool ESP_NOWController::verifyIncomingPacket(const uint8_t mac[6],
                                              const CommunicationData& packet) {
+  if (!hmacAuthenticationEnabled) {
+    return true;
+  }
+
   if (!peerCounterManager.verifyHMAC(mac, reinterpret_cast<const uint8_t*>(&packet),
                                      COMM_DATA_HMAC_DATA_LEN, packet.hmac)) {
     LOG_WARN("[SECURITY] HMAC verification FAILED");
@@ -406,6 +437,45 @@ bool ESP_NOWController::verifyIncomingPacket(const uint8_t mac[6],
   }
 
   return true;
+}
+
+const uint8_t* ESP_NOWController::resolveEspNowLmk(const uint8_t mac[6]) const {
+  if (mac == nullptr) {
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < systemConfig.espNowPeerLmkCount; i++) {
+    const PeerKeyConfig& entry = systemConfig.espNowPeerLmkEntries[i];
+    if (entry.valid && memcmp(entry.mac, mac, 6) == 0) {
+      return entry.key;
+    }
+  }
+
+  if (systemConfig.espNowDefaultLmkConfigured) {
+    return systemConfig.espNowDefaultLmk;
+  }
+
+  return nullptr;
+}
+
+bool ESP_NOWController::isBroadcastOrMulticast(const uint8_t mac[6]) const {
+  if (mac == nullptr) {
+    return false;
+  }
+
+  bool allFF = true;
+  for (size_t i = 0; i < 6; i++) {
+    if (mac[i] != 0xFF) {
+      allFF = false;
+      break;
+    }
+  }
+
+  if (allFF) {
+    return true;
+  }
+
+  return (mac[0] & 0x01) != 0;
 }
 
 void ESP_NOWController::printCounters() const {

--- a/lib/ICSN/controller/ESP-NOWController.hpp
+++ b/lib/ICSN/controller/ESP-NOWController.hpp
@@ -21,7 +21,8 @@ private:
   IForwardingStateBoundary& forwardingStateBoundary;
   PeerCounterManager peerCounterManager;
   InterestPacketTimingBuffer interestTiming;
-  bool encryptionEnabled = false;
+  bool espNowEncryptionEnabled = false;
+  bool hmacAuthenticationEnabled = false;
   uint8_t pmk[PMK_LENGTH] = {0};
 
   ESP_NOWControlData receiveMessage(const uint8_t rxAddress[6], const uint8_t txAddress[6],
@@ -31,6 +32,8 @@ private:
                              bool applySecurity, CommunicationData& outPacket);
   bool verifyIncomingPacket(const uint8_t mac[6], const CommunicationData& packet);
   bool sendPacketToAddresses(const ESP_NOWControlData& data);
+  const uint8_t* resolveEspNowLmk(const uint8_t mac[6]) const;
+  bool isBroadcastOrMulticast(const uint8_t mac[6]) const;
 
 public:
   ESP_NOWController(IInputBoundary& inputBoundary,
@@ -50,7 +53,7 @@ public:
                                esp_now_send_cb_t sendCb, uint8_t channel = 1);
   bool copyPMK(uint8_t* outPmk, size_t outLen) const;
 
-  void registerPeerIfNeeded(const uint8_t mac[6]);
+  bool registerPeerIfNeeded(const uint8_t mac[6]);
   bool sendSensorData(const char* contentName, const char* content, uint8_t hopCount = 1);
   bool sendInterest(const char* contentName, const uint8_t* targetMac, uint8_t hopCount = 1);
   bool processReceivedPacket(const uint8_t myMac[6], const uint8_t senderMac[6],

--- a/lib/ICSN/entity/routing_table/RIBNode.hpp
+++ b/lib/ICSN/entity/routing_table/RIBNode.hpp
@@ -6,7 +6,7 @@
 /// @brief RIB (Routing Information Base) のプレフィックスツリー上の1ノード
 struct RIBNode {
   std::set<std::string> nextHopIds; ///< このコンテンツ名に対する次ホップID集合
-  bool isReal; ///< 実際に学習したルートか（false = 中間ノードのみ）
+  bool isReal;                      ///< 実際に学習したルートか（false = 中間ノードのみ）
 
   RIBNode() : isReal(false) {}
   RIBNode(const std::set<std::string>& ids, bool real) : nextHopIds(ids), isReal(real) {}

--- a/lib/ICSN/entity/routing_table/RIBNode.hpp
+++ b/lib/ICSN/entity/routing_table/RIBNode.hpp
@@ -6,7 +6,8 @@
 /// @brief RIB (Routing Information Base) のプレフィックスツリー上の1ノード
 struct RIBNode {
   std::set<std::string> nextHopIds; ///< このコンテンツ名に対する次ホップID集合
-  bool isReal;                      ///< 実際に学習したルートか（false = 中間ノードのみ）
+  /// 実際に学習したルートか（false = 中間ノードのみ）
+  bool isReal;
 
   RIBNode() : isReal(false) {}
   RIBNode(const std::set<std::string>& ids, bool real) : nextHopIds(ids), isReal(real) {}

--- a/node_profiles/cluster_head.json
+++ b/node_profiles/cluster_head.json
@@ -14,11 +14,17 @@
   "runtime": {
     "max_virtual_depth": 6,
     "hop_count_threshold": 12,
-    "security": {
+    "esp_now_security": {
+      "enabled": true,
       "pmk": "0123456789abcdef0123456789abcdef",
-      "lmk": "fedcba9876543210fedcba9876543210"
+      "default_lmk": "fedcba9876543210fedcba9876543210",
+      "peers": []
     },
-    "peers": [],
+    "icsn_security": {
+      "hmac_enabled": true,
+      "default_hmac_key": "fedcba9876543210fedcba9876543210",
+      "peers": []
+    },
     "fib_init": []
   }
 }

--- a/node_profiles/sensor.json
+++ b/node_profiles/sensor.json
@@ -14,11 +14,17 @@
   "runtime": {
     "max_virtual_depth": 5,
     "hop_count_threshold": 10,
-    "security": {
+    "esp_now_security": {
+      "enabled": true,
       "pmk": "0123456789abcdef0123456789abcdef",
-      "lmk": "fedcba9876543210fedcba9876543210"
+      "default_lmk": "fedcba9876543210fedcba9876543210",
+      "peers": []
     },
-    "peers": [],
+    "icsn_security": {
+      "hmac_enabled": true,
+      "default_hmac_key": "fedcba9876543210fedcba9876543210",
+      "peers": []
+    },
     "fib_init": []
   }
 }

--- a/scripts/generate_node_profile.py
+++ b/scripts/generate_node_profile.py
@@ -34,6 +34,55 @@ def _load_profile(profile_path):
     build = profile.get("build", {})
     runtime = profile.get("runtime", {})
     security = runtime.get("security", {})
+    esp_now_security = runtime.get("esp_now_security", {})
+    icsn_security = runtime.get("icsn_security", {})
+    legacy_peers = runtime.get("peers", [])
+
+    if esp_now_security:
+        esp_now_cfg = {
+            "enabled": bool(esp_now_security.get("enabled", False)),
+            "pmk": str(esp_now_security.get("pmk", "")),
+            "default_lmk": str(esp_now_security.get("default_lmk", "")),
+            "peers": esp_now_security.get("peers", []),
+        }
+    else:
+        # Legacy runtime.security/runtime.peers から新形式へ変換する。
+        legacy_lmk = str(security.get("lmk", ""))
+        esp_now_cfg = {
+            "enabled": bool(security.get("pmk", "")),
+            "pmk": str(security.get("pmk", "")),
+            "default_lmk": legacy_lmk,
+            "peers": [
+                {
+                    "mac": str(peer.get("mac", "")),
+                    "lmk": str(peer.get("lmk", "")),
+                }
+                for peer in legacy_peers
+                if isinstance(peer, dict)
+            ],
+        }
+
+    if icsn_security:
+        icsn_cfg = {
+            "hmac_enabled": bool(icsn_security.get("hmac_enabled", False)),
+            "default_hmac_key": str(icsn_security.get("default_hmac_key", "")),
+            "peers": icsn_security.get("peers", []),
+        }
+    else:
+        # LegacyではLMKをHMAC鍵として使っていたため、互換で引き継ぐ。
+        legacy_lmk = str(security.get("lmk", ""))
+        icsn_cfg = {
+            "hmac_enabled": bool(legacy_lmk),
+            "default_hmac_key": legacy_lmk,
+            "peers": [
+                {
+                    "mac": str(peer.get("mac", "")),
+                    "hmac_key": str(peer.get("lmk", "")),
+                }
+                for peer in legacy_peers
+                if isinstance(peer, dict)
+            ],
+        }
 
     capacities = {
         "fib": _to_positive_int(build.get("fib_capacity"), "build.fib_capacity"),
@@ -65,9 +114,8 @@ def _load_profile(profile_path):
     runtime_config = {
         "MAX_VIRTUAL_DEPTH": int(runtime.get("max_virtual_depth", 5)),
         "HOP_COUNT_THRESHOLD": int(runtime.get("hop_count_threshold", 10)),
-        "PMK": str(security.get("pmk", "")),
-        "LMK": str(security.get("lmk", "")),
-        "peers": runtime.get("peers", []),
+        "esp_now_security": esp_now_cfg,
+        "icsn_security": icsn_cfg,
         "fib_init": runtime.get("fib_init", []),
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ constexpr float INTEREST_INTERVAL_SEC = 10.0f;
 constexpr float AUTO_INTEREST_DELAY_SEC = 40.0f;
 constexpr bool AUTO_SENSOR_ENABLED = false; // 起動後の自動センサデータ読み取りを有効にするかどうか
 constexpr bool AUTO_INTEREST_ENABLED = false; // 起動後の自動INTEREST送信を有効にするかどうか
-constexpr uint32_t LOOP_IDLE_DELAY_MS = 5; // Allow IDLE task scheduling & reduce active time
+constexpr uint32_t LOOP_IDLE_DELAY_MS = 5;    // Allow IDLE task scheduling & reduce active time
 #if ICSN_PERF_ENABLED
 constexpr float MEMORY_LOG_INTERVAL_SEC = 30.0f;
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,8 @@ constexpr float INTEREST_INTERVAL_SEC = 10.0f;
 constexpr float AUTO_INTEREST_DELAY_SEC = 40.0f;
 constexpr bool AUTO_SENSOR_ENABLED = false; // 起動後の自動センサデータ読み取りを有効にするかどうか
 constexpr bool AUTO_INTEREST_ENABLED = false; // 起動後の自動INTEREST送信を有効にするかどうか
-constexpr uint32_t LOOP_IDLE_DELAY_MS = 5;    // Allow IDLE task scheduling & reduce active time
+// Allow IDLE task scheduling & reduce active time
+constexpr uint32_t LOOP_IDLE_DELAY_MS = 5;
 #if ICSN_PERF_ENABLED
 constexpr float MEMORY_LOG_INTERVAL_SEC = 30.0f;
 #endif


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>概要</h2><p>ESP-NOW標準のPMK／LMKを使用したCCMP暗号化を正しく有効化し、ESP-NOW用の暗号鍵とICSNパケットのHMAC認証鍵を個別に管理できるようにしました。</p><p>従来はPMKを設定していても、peer登録時に<code inline="">peer.encrypt = false</code>となっており、ESP-NOWの通信フレームは暗号化されていませんでした。また、<code inline="">LMK</code>がESP-NOW暗号化用の鍵とICSNパケットのHMAC鍵を兼ねており、設定名と実際の用途が一致していませんでした。</p><p>本PRでは、設定・実装・ドキュメントを整理し、暗号化が有効な状態でLMKが見つからない場合に、非暗号化通信へ暗黙的にフォールバックしないようにしています。</p><h2>変更内容</h2><h3>ESP-NOW CCMP暗号化の有効化</h3><p>peer登録時に、対象MACアドレスに対応するLMKを<code inline="">esp_now_peer_info_t::lmk</code>へ設定し、ユニキャストpeerの<code inline="">peer.encrypt</code>を<code inline="">true</code>にするよう変更しました。</p><p>LMKは次の優先順位で解決します。</p><ol><li><p><code inline="">esp_now_security.peers[].lmk</code>のpeer固有LMK</p></li><li><p><code inline="">esp_now_security.default_lmk</code></p></li><li><p>LMKが見つからない場合はpeer登録失敗</p></li></ol><p>暗号化が有効であるにもかかわらずLMKを解決できない場合は、非暗号化peerとして登録せず、パケット送信を中止します。</p><p>ブロードキャストおよびマルチキャストアドレスは、ESP-NOW標準のCCMP暗号化対象外として扱います。</p><h3>ESP-NOW用鍵とHMAC鍵の分離</h3><p>セキュリティ設定を、用途ごとに次の2つへ分離しました。</p><pre><code class="language-json">{
  "esp_now_security": {
    "enabled": true,
    "pmk": "0123456789abcdef0123456789abcdef",
    "default_lmk": "fedcba9876543210fedcba9876543210",
    "peers": [
      {
        "mac": "CC:7B:5C:9A:F3:C4",
        "lmk": "11111111111111111111111111111111"
      }
    ]
  },
  "icsn_security": {
    "hmac_enabled": true,
    "default_hmac_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "peers": [
      {
        "mac": "CC:7B:5C:9A:F3:C4",
        "hmac_key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
      }
    ]
  }
}
</code></pre><p>それぞれの用途は以下のとおりです。</p>
設定 | 用途
-- | --
esp_now_security.pmk | ESP-NOWへ設定するPMK
esp_now_security.default_lmk | CCMP用のデフォルトLMK
esp_now_security.peers[].lmk | CCMP用のpeer固有LMK
icsn_security.default_hmac_key | ICSNパケット用のデフォルトHMAC鍵
icsn_security.peers[].hmac_key | ICSNパケット用のpeer固有HMAC鍵

<p>ESP-NOW CCMP暗号化とICSN HMAC認証の有効状態も、それぞれ独立したフラグで管理します。</p><h3>設定読み込み処理の更新</h3><p><code inline="">SystemConfig</code>へ以下の設定を追加しました。</p><ul><li><p>ESP-NOW暗号化の有効状態</p></li><li><p>PMKおよびデフォルトLMK</p></li><li><p>peer固有LMK一覧</p></li><li><p>HMAC認証の有効状態</p></li><li><p>デフォルトHMAC鍵</p></li><li><p>peer固有HMAC鍵一覧</p></li></ul><p>MACアドレスと16バイト鍵の読み込み処理を共通化し、不正な形式の設定は有効な鍵として登録しないようにしています。</p><h3>旧設定形式との後方互換</h3><p>従来の設定形式も引き続き読み込めるようにしています。</p><pre><code class="language-json">{
  "PMK": "...",
  "LMK": "...",
  "peers": []
}
</code></pre><p>旧形式を読み込んだ場合は、次のように移行します。</p><ul><li><p><code inline="">PMK</code>をESP-NOW用PMKとして使用</p></li><li><p><code inline="">LMK</code>をESP-NOW用デフォルトLMKとして使用</p></li><li><p>従来動作との互換性のため、<code inline="">LMK</code>をHMAC用デフォルト鍵としても使用</p></li><li><p><code inline="">peers[].lmk</code>をCCMP用LMKとHMAC鍵の両方へ移行</p></li><li><p>非推奨設定であることを警告ログへ出力</p></li></ul><p>鍵の実値はログへ出力しません。</p><h3>ノードプロファイル生成処理の更新</h3><p><code inline="">sensor</code>および<code inline="">cluster_head</code>のノードプロファイルを新しいセキュリティ設定形式へ変更しました。</p><p><code inline="">generate_node_profile.py</code>についても以下へ対応しています。</p><ul><li><p>新しい<code inline="">esp_now_security</code>設定の生成</p></li><li><p>新しい<code inline="">icsn_security</code>設定の生成</p></li><li><p>旧<code inline="">runtime.security</code>／<code inline="">runtime.peers</code>形式からの変換</p></li><li><p>生成される<code inline="">config.json</code>への新形式の反映</p></li></ul><h3>ドキュメントの更新</h3><p>READMEのセキュリティ説明と設定例を更新しました。</p><ul><li><p>PMK、LMK、HMAC鍵の役割</p></li><li><p>peer登録時にLMKと<code inline="">peer.encrypt = true</code>が必要であること</p></li><li><p>CCMPとHMACが異なるセキュリティ層であること</p></li><li><p>ブロードキャスト／マルチキャストはCCMP暗号化対象外であること</p></li><li><p>新しい<code inline="">config.json</code>の設定項目</p></li></ul><h2>セキュリティ層</h2><pre><code class="language-text">ICSN packet
├─ signalCode
├─ hopCount
├─ contentName
├─ content
├─ counter
└─ HMAC-SHA256
        ↓
ESP-NOW
└─ LMKを使用したCCMP暗号化
        ↓
Wi-Fiベンダー固有アクションフレーム
</code></pre><p>CCMPは隣接ノード間の無線通信を保護し、HMACはICSNパケットの送信元認証と完全性を保護します。</p><h2>影響範囲</h2><p>主な変更範囲は以下です。</p><ul><li><p><code inline="">lib/ICSN/config</code></p></li><li><p><code inline="">lib/ICSN/controller/ESP-NOWController</code></p></li><li><p><code inline="">data/config.json</code></p></li><li><p><code inline="">node_profiles</code></p></li><li><p><code inline="">scripts/generate_node_profile.py</code></p></li><li><p><code inline="">README.md</code></p></li></ul><p>Use Case、Entity、FIB、PIT、CSの処理方式は変更していません。</p><h2>確認項目</h2><h3>ビルド</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e normal</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e perf</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e release</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e normal_s3</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e perf_s3</code></p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> <code inline="">pio run -e release_s3</code></p></li></ul><h3>実機確認</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> 同一PMK／LMKを設定した2台間でユニキャスト通信できる</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 一方のLMKを変更するとESP-NOW通信が成立しない</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> LMKを一致させ、HMAC鍵だけ変更するとHMAC検証で破棄される</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 暗号化有効かつLMK未設定の場合、peer登録が失敗する</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 暗号化無効時は非暗号化peerとして登録される</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> ブロードキャスト／マルチキャストが非暗号化peerとして処理される</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> PMK、LMK、HMAC鍵の実値がログへ出力されない</p></li></ul><p>Closes #64</p></body></html><!--EndFragment-->
</body>
</html>