### PR TITLE
add "pit remove"

### DIFF
--- a/lib/ICSN/use_case/UseCaseInteractor.cpp
+++ b/lib/ICSN/use_case/UseCaseInteractor.cpp
@@ -83,6 +83,8 @@ OutputData UseCaseInteractor::handleDataReceive(const InputData& inputData) {
   if (pitRepository.find(contentName)) {
     const DestinationId requesters = pitRepository.get(contentName);
 
+    pitRepository.remove(contentName);
+
     // CSにキャッシュ
     CSPair csPair(contentName, content);
     csRepository.save(csPair);


### PR DESCRIPTION
# 概要

- Data転送後にPITエントリを削除する処理を追加しました。

Closes #72

# 主な変更点

- Data転送完了後にPITエントリを削除する処理を追加
- `IPendingInterestTable`の`remove()`を利用してPITエントリを削除
- 不要となったPITエントリが残らないよう修正

# レビュアーが注視すべき点

- Data転送後に対象のPITエントリが正しく削除されるか
- PIT削除後もData転送やInterest処理に影響がないか

# 確認

- [x] CIで検出できない範囲を必要に応じて手動確認しました．
- [x] 機密情報（トークン等）を含んでいません．