### PR TITLE
Change to CountLimit

### DIFF
--- a/lib/ICSN/config/Config.cpp
+++ b/lib/ICSN/config/Config.cpp
@@ -172,7 +172,7 @@ bool loadSystemConfig(const char* path) {
   }
 
   systemConfig.maxVirtualDepth = doc["MAX_VIRTUAL_DEPTH"] | 5;
-  systemConfig.hopCountThreshold = doc["HOP_COUNT_THRESHOLD"] | 10;
+  systemConfig.defaultInterestHopLimit = doc["default_interest_hop_limit"] | 10;
 
   resetSecurityConfig();
   if (doc.containsKey("esp_now_security") || doc.containsKey("icsn_security")) {
@@ -209,7 +209,7 @@ bool loadSystemConfig(const char* path) {
   LOG_INFOF(
       "[INFO][CFG] config_loaded path=%s max_virtual_depth=%d hop_limit=%d fib_init_entries=%u\n",
       path != nullptr ? path : "(null)", systemConfig.maxVirtualDepth,
-      systemConfig.hopCountThreshold, static_cast<unsigned int>(systemConfig.fibInitCount));
+      systemConfig.defaultInterestHopLimit, static_cast<unsigned int>(systemConfig.fibInitCount));
 
   return true;
 }

--- a/lib/ICSN/config/Config.hpp
+++ b/lib/ICSN/config/Config.hpp
@@ -33,7 +33,7 @@ constexpr size_t MAX_FIB_INIT_ENTRIES = 10;
 
 struct SystemConfig {
   int maxVirtualDepth = 5;
-  int hopCountThreshold = 10;
+  int defaultInterestHopLimit = 10;
 
   // ESP-NOW CCMP 設定
   bool espNowEncryptionEnabled = false;

--- a/lib/ICSN/controller/ESP-NOWController.cpp
+++ b/lib/ICSN/controller/ESP-NOWController.cpp
@@ -215,13 +215,13 @@ bool ESP_NOWController::registerConfiguredEspNowPeers() {
 }
 
 bool ESP_NOWController::sendSensorData(const char* contentName, const char* content,
-                                       uint8_t hopCount) {
+                                       uint8_t hopLimit) {
   if (contentName == nullptr || content == nullptr) {
     return false;
   }
 
   ESP_NOWControlData sensorData = {};
-  sensorData.hopCount = hopCount;
+  sensorData.hopCount = hopLimit;
   strncpy(sensorData.signalCode, "DATA", MAX_SIGNAL_CODE_LENGTH - 1);
   sensorData.signalCode[MAX_SIGNAL_CODE_LENGTH - 1] = '\0';
   strncpy(sensorData.contentName, contentName, MAX_CONTENT_NAME_LENGTH - 1);
@@ -234,7 +234,7 @@ bool ESP_NOWController::sendSensorData(const char* contentName, const char* cont
 }
 
 bool ESP_NOWController::sendInterest(const char* contentName, const uint8_t* targetMac,
-                                     uint8_t hopCount) {
+                                     uint8_t hopLimit) {
   if (contentName == nullptr || targetMac == nullptr) {
     return false;
   }
@@ -244,7 +244,7 @@ bool ESP_NOWController::sendInterest(const char* contentName, const uint8_t* tar
 
   strncpy(interest.signalCode, "INTEREST", MAX_SIGNAL_CODE_LENGTH - 1);
   interest.signalCode[MAX_SIGNAL_CODE_LENGTH - 1] = '\0';
-  interest.hopCount = hopCount;
+  interest.hopCount = hopLimit;
   strncpy(interest.contentName, contentName, MAX_CONTENT_NAME_LENGTH - 1);
   interest.contentName[MAX_CONTENT_NAME_LENGTH - 1] = '\0';
   strncpy(interest.content, "N/A", MAX_CONTENT_LENGTH - 1);

--- a/lib/ICSN/data_structure/InputData.hpp
+++ b/lib/ICSN/data_structure/InputData.hpp
@@ -9,13 +9,13 @@ struct InputData {
   std::string senderId;
   std::set<std::string> destId;
   std::string signalCode;
-  int hopCount;
+  int hopLimit;
   std::string contentName;
   std::string content;
 
   InputData(const std::string& senderId, const std::set<std::string>& destId,
-            const std::string& signalCode, int hopCount, const std::string& contentName,
+            const std::string& signalCode, int hopLimit, const std::string& contentName,
             const std::string& content)
-      : senderId(senderId), destId(destId), signalCode(signalCode), hopCount(hopCount),
+      : senderId(senderId), destId(destId), signalCode(signalCode), hopLimit(hopLimit),
         contentName(contentName), content(content) {}
 };

--- a/lib/ICSN/entity/message/HopLimit.hpp
+++ b/lib/ICSN/entity/message/HopLimit.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-class HopCount {
+class HopLimit {
 private:
   int cnt;
 
 public:
-  HopCount(int cnt) : cnt(cnt) {}
+  HopLimit(int cnt) : cnt(cnt) {}
   int getValue() const {
     return cnt;
-  };
-  void increment() {
-    cnt++;
   };
 };

--- a/lib/ICSN/use_case/UseCaseInteractor.cpp
+++ b/lib/ICSN/use_case/UseCaseInteractor.cpp
@@ -5,7 +5,7 @@
 #include "message/Content.hpp"
 #include "message/ContentName.hpp"
 #include "message/DestinationId.hpp"
-#include "message/HopCount.hpp"
+#include "message/HopLimit.hpp"
 #include "message/SenderId.hpp"
 #include "message/SignalCode.hpp"
 
@@ -21,20 +21,20 @@ UseCaseInteractor::UseCaseInteractor(IForwardingInformationBase& fibRepository,
 OutputData UseCaseInteractor::handleInterestReceive(const InputData& inputData) {
   SenderId senderId(inputData.senderId);
   DestinationId destinationId({inputData.destId});
-  HopCount hopcount(inputData.hopCount);
+  HopLimit hopLimit(inputData.hopLimit);
   ContentName contentName(inputData.contentName);
   Content content(inputData.content);
 
   // INTEREST受信時の処理
   // ホップカウントチェック（転送時の値で判定）
-  if (hopcount.getValue() + 1 >= systemConfig.hopCountThreshold) {
-    LOG_DEBUGF("[DEBUG][UC] interest_dropped reason=hop_limit name=%s hop=%d limit=%d\n",
-               contentName.getValue().c_str(), hopcount.getValue() + 1,
-               systemConfig.hopCountThreshold);
-    // パケット破棄
-    return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID), hopcount.getValue() + 1,
-                      VALUE_NA, VALUE_NA);
+  if (hopLimit.getValue() == 0) {
+    LOG_DEBUGF("[DEBUG][UC] interest_dropped reason=hop_limit name=%s\n",
+               contentName.getValue().c_str());
+
+    return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID), 0, VALUE_NA, VALUE_NA);
   }
+
+  const uint8_t nextHopLimit = hopLimit.getValue() - 1;
 
   if (csRepository.find(contentName)) {
     LOG_DEBUGF("[DEBUG][UC] interest_cs_hit name=%s\n", contentName.getValue().c_str());
@@ -55,27 +55,26 @@ OutputData UseCaseInteractor::handleInterestReceive(const InputData& inputData) 
     if (fibRepository.find(contentName)) {
       const DestinationId nextHops = fibRepository.get(contentName);
       LOG_DEBUGF("[DEBUG][UC] interest_forward name=%s hop=%d next_hops=%u\n",
-                 contentName.getValue().c_str(), hopcount.getValue() + 1,
+                 contentName.getValue().c_str(), hopLimit.getValue(),
                  static_cast<unsigned int>(nextHops.getValue().size()));
       // FIBテーブルに基づいてINTEREST送信 (転送なのでホップ数+1)
-      return makeOutput(*destinationId.getValue().begin(), nextHops.getValue(),
-                        toString(SignalCode::INTEREST), hopcount.getValue() + 1,
-                        contentName.getValue(), content.getValue());
+      return makeOutput(VALUE_NA, destinationId.getValue(), toString(SignalCode::INTEREST),
+                        nextHopLimit, contentName.getValue(), VALUE_NA);
+
     } else {
       LOG_DEBUGF("[DEBUG][UC] interest_dropped reason=fib_miss name=%s\n",
                  contentName.getValue().c_str());
-      // FIB未ヒット時はブロードキャストせず破棄
-      return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID),
-                        hopcount.getValue() + 1, VALUE_NA, VALUE_NA);
+
+      return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID), nextHopLimit, VALUE_NA,
+                        VALUE_NA);
     }
   }
-};
-
+}
 /// @brief Dataパケットを受信したときの処理
 /// @param inputData 入力された Data データ構造
 /// @return 応答パケット（DATA, INVALID）
 OutputData UseCaseInteractor::handleDataReceive(const InputData& inputData) {
-  HopCount hopcount(inputData.hopCount);
+  HopLimit hopLimit(inputData.hopLimit);
   ContentName contentName(inputData.contentName);
   Content content(inputData.content);
 
@@ -95,12 +94,12 @@ OutputData UseCaseInteractor::handleDataReceive(const InputData& inputData) {
 
     // PITに基づいてデータ送信 (転送なのでホップ数+1)
     return makeOutput(origin, requesters.getValue(), toString(SignalCode::DATA),
-                      hopcount.getValue() + 1, contentName.getValue(), content.getValue());
+                      hopLimit.getValue(), contentName.getValue(), content.getValue());
   } else {
     LOG_DEBUGF("[DEBUG][UC] data_dropped reason=pit_miss name=%s\n",
                contentName.getValue().c_str());
     // パケット破棄 (対応するINTERESTがない)
-    return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID), hopcount.getValue() + 1,
+    return makeOutput(VALUE_NA, {VALUE_NA}, toString(SignalCode::INVALID), hopLimit.getValue() + 1,
                       VALUE_NA, VALUE_NA);
   }
 };


### PR DESCRIPTION
# 概要

- InterestのCount Limitを導入し，転送回数を制限する処理を追加しました。

Closes #73

# 主な変更点

- InterestパケットにCount Limitを追加
- Interest転送時にCount Limitを更新する処理を実装
- Count Limitに達したInterestは転送しないよう変更

# レビュアーが注視すべき点

- Count Limitが期待どおりに更新されるか
- Count Limit到達時にInterestの転送が停止するか
- Count Limit未到達時は従来どおりInterestが転送されるか

# 確認

- [x] CIで検出できない範囲を必要に応じて手動確認しました．
- [x] 機密情報（トークン等）を含んでいません．